### PR TITLE
[C4-860] Adds support for forOfStatements and arrowFunctionExpressions

### DIFF
--- a/lib/pass/dead-code-elimination.js
+++ b/lib/pass/dead-code-elimination.js
@@ -410,6 +410,18 @@
                     status.revive();
                     return this.skip();
 
+                case Syntax.ForOfStatement:
+                    live |= visit(node.left);
+                    live |= visit(node.right);
+
+                    status.jumps.push(new JumpTarget(node, status, JumpTarget.ITERATION));
+                    live |= visitLoopBody(node, node.body);
+                    status.jumps.pop();
+
+                    status.resolveJump(node);
+                    status.revive();
+                    return this.skip();
+
                 case Syntax.IfStatement:
                     live |= visit(node.test);
                     live |= visit(node.consequent);

--- a/lib/pass/remove-wasted-blocks.js
+++ b/lib/pass/remove-wasted-blocks.js
@@ -71,6 +71,12 @@
         result = estraverse.replace(result, {
             leave: function leave(node, parent) {
                 var i, iz, stmt;
+
+                if (node.type === Syntax.BlockStatement &&
+                    parent.type === Syntax.ArrowFunctionExpression
+                ) {
+                    return;
+                }
                 // remove nested blocks
                 if (node.type === Syntax.BlockStatement || node.type === Syntax.Program) {
                     for (i = 0, iz = node.body.length; i < iz; ++i) {

--- a/lib/pass/remove-wasted-blocks.js
+++ b/lib/pass/remove-wasted-blocks.js
@@ -75,8 +75,17 @@
                 if (node.type === Syntax.BlockStatement &&
                     parent.type === Syntax.ArrowFunctionExpression
                 ) {
-                    return;
+                    if (
+                        node.body.length &&
+                        node.body[0].type === Syntax.ReturnStatement &&
+                        /Expression$/.test(node.body[0].argument.type)
+                    ) {
+                        node.body[0] = node.body[0].argument;
+                    } else {
+                        return;
+                    }
                 }
+
                 // remove nested blocks
                 if (node.type === Syntax.BlockStatement || node.type === Syntax.Program) {
                     for (i = 0, iz = node.body.length; i < iz; ++i) {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "escodegen": "~1.6.1",
     "escope": "~2.0.6",
     "esprima": "^2.0.0",
-    "estraverse": "~4.1.1",
-    "esutils": "~2.0.2",
     "esshorten": "git+https://github.com/jscrambler/esshorten.git#all-fixes",
+    "estraverse": "^4.2.0",
+    "esutils": "~2.0.2",
     "isarray": "0.0.1",
     "optionator": "^0.5.0",
     "source-map": "^0.4.1"


### PR DESCRIPTION
* Properly handle forOfStatements
* Fix bug that was causing arrow functions wrapped with `{}` to break the code when `esmangle` removed the wrapping
* Update `estraverse` version